### PR TITLE
Add basic support for RP-initiated logout

### DIFF
--- a/OpenIDConnectExample/AppDelegate.swift
+++ b/OpenIDConnectExample/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
     var currentAuthorizationSession: OIDAuthorizationFlowSession?
-
+    var currentLogoutSession: LoginGovService.LogoutSession?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         return true
@@ -28,6 +28,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        if let currentLogoutSession = currentLogoutSession {
+            if currentLogoutSession.resumeLogout(with: url) {
+                return true;
+            }
+        }
+
         return currentAuthorizationSession!.resumeAuthorizationFlow(with: url);
     }
 

--- a/OpenIDConnectExample/LoginViewController.swift
+++ b/OpenIDConnectExample/LoginViewController.swift
@@ -31,9 +31,9 @@ class LoginViewController: UIViewController {
             let authRequest = LoginGovService.authorizationRequest(serviceConfiguration: serviceConfiguration)
 
             delegate.currentAuthorizationSession = OIDAuthorizationService
-                .present(authRequest, presenting: self) { (authReponse: OIDAuthorizationResponse?, error: Error?) in
+                .present(authRequest, presenting: self) { (authResponse: OIDAuthorizationResponse?, error: Error?) in
 
-                    guard let authorizationCode = authReponse?.authorizationCode else {
+                    guard let authorizationCode = authResponse?.authorizationCode else {
                         self.showError(error: error!)
                         return
                     }
@@ -48,6 +48,8 @@ class LoginViewController: UIViewController {
                             self.showError(error: error!)
                             return
                         }
+
+                        delegate.currentLogoutSession = LoginGovService.LogoutSession(serviceConfiguration: serviceConfiguration, idToken: tokenResponse!.idToken!)
 
                         LoginGovService.loadUserinfo(serviceConfiguration: serviceConfiguration, accessToken: accessToken, callback: { (json : Any?, error : Error?) in
                             if let json = json {

--- a/OpenIDConnectExample/ProfileController.swift
+++ b/OpenIDConnectExample/ProfileController.swift
@@ -6,7 +6,11 @@ class ProfileController : UIViewController {
     @IBOutlet weak var textView: UITextView!
 
     @IBAction func signOut(_ sender: Any) {
-        self.navigationController!.popViewController(animated: true)
+        let delegate = UIApplication.shared.delegate! as! AppDelegate
+
+        delegate.currentLogoutSession?.present(presenting: self) {
+            self.navigationController!.popViewController(animated: true)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
**Why**: To support real logout

--

The AppAuth library we use does not support RP-initiated logout, so I had to roll this on my own, we should see if the framework authors are interested in accepting a contribution to add it.